### PR TITLE
Handle null price in formatter

### DIFF
--- a/app/Helper/helper.php
+++ b/app/Helper/helper.php
@@ -760,10 +760,15 @@ if (!function_exists('getVerificationFields')) {
 if (!function_exists('formatPriceWithCurrency')) {
     function formatPriceWithCurrency($price)
     {
+        // Gracefully handle null values to avoid a TypeError when formatting
+        if ($price === null) {
+            return '';
+        }
+
         $currencySymbol = config('app.currency_symbol'); // Fetch currency symbol from config
         $locale = getPaymentSystemSetting('currency_locale') ?? 'en_US'; // Default to 'en_US' if not set
 
-        $formattedPrice = Number::format($price, locale: $locale);
+        $formattedPrice = Number::format((float) $price, locale: $locale);
 
         return isDisplayCurrencyAfterPrice()
             ? "{$formattedPrice} {$currencySymbol}"


### PR DESCRIPTION
## Summary
- avoid TypeError in `formatPriceWithCurrency` when price is null

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684a26aaf2b8832194b18f0d653d4983