### PR TITLE
Override Livewire upload route

### DIFF
--- a/app/Http/Controllers/Livewire/CustomFileUploadController.php
+++ b/app/Http/Controllers/Livewire/CustomFileUploadController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Livewire;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+
+/**
+ * Overrides Livewire's default temporary file upload endpoint.
+ *
+ * Each uploaded file is validated using the rules defined in
+ * `config('livewire.temporary_file_upload.rules')`. Files without a
+ * real path are rejected and a 400 response is returned.
+ */
+class CustomFileUploadController extends Controller
+{
+    public function handle(Request $request)
+    {
+        $rules = config('livewire.temporary_file_upload.rules');
+
+        $request->validate([
+            'files.*' => $rules,
+        ]);
+
+        /** @var UploadedFile $file */
+        foreach ($request->file('files', []) as $file) {
+            if (empty($file->getRealPath())) {
+                return response()->json(['message' => 'Invalid file'], 400);
+            }
+
+            $file->storeAs(
+                config('livewire.temporary_file_upload.directory'),
+                $file->hashName(),
+                ['disk' => config('livewire.temporary_file_upload.disk')]
+            );
+        }
+
+        return response()->json(['message' => 'Files uploaded']);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Livewire\Reservation\CartSummary;
 use App\Livewire\Reservation\CheckoutSummary;
 use App\Livewire\Reservation\Purchases\MyPurchases;
 use App\Livewire\Reservation\Purchases\ViewPurchase;
+use App\Http\Controllers\Livewire\CustomFileUploadController;
 use App\Livewire\User\MyAccount;
 use App\Livewire\User\PageDetail;
 use App\Livewire\User\Contact;
@@ -40,6 +41,9 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/manifest.json', '\App\Http\Controllers\PwaController@manifest');
+
+// Override Livewire's default upload endpoint
+Route::post('/livewire/upload-file', [CustomFileUploadController::class, 'handle']);
 
 Route::get('/', function () {
     return view('welcome');


### PR DESCRIPTION
## Summary
- implement `CustomFileUploadController` for Livewire uploads
- override `/livewire/upload-file` route to use the new controller

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6c4449308321820077d9fe7422c5