### PR TITLE
Fix Livewire upload route naming

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -47,7 +47,8 @@ Livewire::routes();
 Route::get('/manifest.json', '\App\Http\Controllers\PwaController@manifest');
 
 // Override Livewire's default upload endpoint
-Route::post('/livewire/upload-file', [CustomFileUploadController::class, 'handle']);
+Route::post('/livewire/upload-file', [CustomFileUploadController::class, 'handle'])
+    ->name('livewire.upload-file');
 
 Route::get('/', function () {
     return view('welcome');


### PR DESCRIPTION
## Summary
- fix `livewire.upload-file` route registration

## Testing
- `composer test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b0434078c8321a692689fdc3b24e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a named route for the Livewire file upload endpoint, making it easier to reference this route elsewhere in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->