### PR TITLE
Fix tiptap plugin path in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,7 @@ export default {
     './app-modules/**/src/Livewire/**/*.php',
     './app-modules/**/src/Filament/**/*.php',
     './app-modules/**/resources/views/**/*.php',
-    '/vendor/awcodes/filament-tiptap-editor/resources/**/*.blade.php',
+    './vendor/awcodes/filament-tiptap-editor/resources/**/*.blade.php',
   ],
   theme: {
         screens: {


### PR DESCRIPTION
## Summary
- make Tailwind scan TipTap editor templates by prepending `./` to the plugin path

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b147246ac8321b0de244c0a46c067