### PR TITLE
Fix dd usage in Maintenance page

### DIFF
--- a/app/Filament/Pages/System/Maintenance.php
+++ b/app/Filament/Pages/System/Maintenance.php
@@ -78,7 +78,7 @@ class Maintenance extends SettingsPage
                 Config::write('maintenance.message', str_replace(["'", '"'], '', $data['message']));
                 Config::write('maintenance.secret', $data['secret']);
             } catch (Exception $ex) {
-                dd($ex->getMessage());
+                logger()->error($ex->getMessage());
             }
 
             // Notify the logged-in user


### PR DESCRIPTION
## Summary
- replace `dd()` debugging call with error logging in maintenance page

## Testing
- `vendor/bin/pest --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b146dabfc8321bbaae49107bf3204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during maintenance mode configuration by logging errors instead of displaying them, resulting in a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->