### PR TITLE
Update user factory password hash

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -21,7 +21,8 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            // bcrypt hash for the string "password" using cost 4
+            'password' => '$2b$04$yqYZBmNcgb1AYN4LV4hEBeCGs2hU8GRG8QyovqT7hvn3NlZDkKrZa',
             'remember_token' => Str::random(10),
         ];
     }


### PR DESCRIPTION
## Summary
- use bcrypt cost 4 in `UserFactory`
- confirm bcrypt rounds in `phpunit.xml`

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b16ff0a888321873472410c089c1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the default user password hash in the database factory to use a different bcrypt version and cost factor.
	- Added a comment clarifying the password hash details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->