### PR TITLE
Fix repeated loading of constants

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -1,5 +1,6 @@
 <?php
-const CURRENCY_LOCALE = [
+if (!defined('CURRENCY_LOCALE')) {
+    define('CURRENCY_LOCALE', [
     'af_NA' => "Afrikaans (Namibia)",
     'af_ZA' => "Afrikaans (South Africa)",
     'af' => "Afrikaans",
@@ -436,13 +437,26 @@ const CURRENCY_LOCALE = [
     'yo' => "Yoruba",
     'zu_ZA' => "Zulu (South Africa)",
     'zu' => "Zulu"
-];
+    ]);
+}
 
 
-const CLASSIFIED_MARKETPLACE = 'classified';
-const ONLINE_SHOP_MARKETPLACE = 'online_shop';
-const VEHICLE_RENTAL_MARKETPLACE = 'vehicle_rental';
-const POINT_SYSTEM_MARKETPLACE = 'point_system';
+if (!defined('CLASSIFIED_MARKETPLACE')) {
+    define('CLASSIFIED_MARKETPLACE', 'classified');
+}
+if (!defined('ONLINE_SHOP_MARKETPLACE')) {
+    define('ONLINE_SHOP_MARKETPLACE', 'online_shop');
+}
+if (!defined('VEHICLE_RENTAL_MARKETPLACE')) {
+    define('VEHICLE_RENTAL_MARKETPLACE', 'vehicle_rental');
+}
+if (!defined('POINT_SYSTEM_MARKETPLACE')) {
+    define('POINT_SYSTEM_MARKETPLACE', 'point_system');
+}
 
-const RESERVATION_TYPE_RETAIL =  'retail';
-const RESERVATION_TYPE_POINT_VAULT =  'point_vault';
+if (!defined('RESERVATION_TYPE_RETAIL')) {
+    define('RESERVATION_TYPE_RETAIL', 'retail');
+}
+if (!defined('RESERVATION_TYPE_POINT_VAULT')) {
+    define('RESERVATION_TYPE_POINT_VAULT', 'point_vault');
+}


### PR DESCRIPTION
## Summary
- guard constants in `config/constants.php` with `defined()` checks to avoid `Constant already defined` warnings

## Testing
- `composer install` *(fails: `composer: command not found`)*
- `php ./vendor/bin/pest` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b1703e15083218bb8b1e4c42c49a0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved handling of constant definitions to prevent potential redefinition errors or warnings. No changes to existing features or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->