### PR TITLE
Replace country code column with iso2

### DIFF
--- a/database/migrations/2023_10_13_102123_create_countries_table.php
+++ b/database/migrations/2023_10_13_102123_create_countries_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('countries', function (Blueprint $table) {
             $table->id();
             $table->string('name', 60);
-            $table->string('code', 3)->unique();
+            $table->string('iso2', 2)->unique();
             $table->boolean('is_active')->default(true);
             $table->timestamps();
             $table->softDeletes();


### PR DESCRIPTION
## Summary
- update the countries table migration to use `iso2` instead of `code`

## Testing
- `php artisan migrate:fresh` *(fails: php not found)*
- `php artisan db:seed` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3cea5e588321844ecbc03deb806b