### PR TITLE
Set default search radius when settings missing

### DIFF
--- a/app/Livewire/Ad/AdList.php
+++ b/app/Livewire/Ad/AdList.php
@@ -140,7 +140,7 @@ class AdList extends Component
 
         $latitude = session('latitude', null);
         $longitude = session('longitude', null);
-        $search_radius = app(LocationSettings::class)->search_radius;
+        $search_radius = app(LocationSettings::class)->search_radius ?? 100;
         $radius = $search_radius;
         $selectedCountry = session('country', null);
         $selectedState = session('state', null);

--- a/app/Livewire/AdType/AdTypeCollection.php
+++ b/app/Livewire/AdType/AdTypeCollection.php
@@ -207,7 +207,7 @@ class AdTypeCollection extends Component
 
         $latitude = session('latitude', null);
         $longitude = session('longitude', null);
-        $search_radius = app(LocationSettings::class)->search_radius;
+        $search_radius = app(LocationSettings::class)->search_radius ?? 100;
         $radius = $search_radius;
         $selectedCountry = session('country', null);
         $selectedState = session('state', null);

--- a/app/Livewire/Home/Home.php
+++ b/app/Livewire/Home/Home.php
@@ -153,7 +153,7 @@ class Home extends Component
     {
         $latitude = session('latitude', null);
         $longitude = session('longitude', null);
-        $search_radius = app(LocationSettings::class)->search_radius;
+        $search_radius = app(LocationSettings::class)->search_radius ?? 100;
         $locationType = session('locationType', null);
         $selectedCountry = session('country', null);
         $selectedState = session('state', null);


### PR DESCRIPTION
## Summary
- default `search_radius` setting to 100 km when not set

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b42d1324083218ea8f55e3bb5def4