### PR TITLE
Initialize LocationSettings defaults

### DIFF
--- a/app/Settings/LocationSettings.php
+++ b/app/Settings/LocationSettings.php
@@ -7,12 +7,38 @@ use Spatie\LaravelSettings\Settings;
 class LocationSettings extends Settings
 {
 
-    public array $allowed_countries;
-    public string $default_country;
-    public array $allowed_states;
-    public int $search_radius;
-    public bool $enable_location_auto_detection;
-    public string $location_source;
+    /**
+     * Countries that users can select from.
+     *
+     * Defaults to an empty array so the application can boot
+     * even before the settings migrations are executed.
+     */
+    public array $allowed_countries = [];
+
+    /**
+     * ISO code of the default country.
+     */
+    public string $default_country = 'US';
+
+    /**
+     * States that users can select from.
+     */
+    public array $allowed_states = [];
+
+    /**
+     * Default search radius used when filtering locations (in km).
+     */
+    public int $search_radius = 100;
+
+    /**
+     * Automatically detect user location on the frontend.
+     */
+    public bool $enable_location_auto_detection = false;
+
+    /**
+     * Data source for location queries.
+     */
+    public string $location_source = 'openstreet';
 
     public static function group(): string
     {


### PR DESCRIPTION
## Summary
- set default values for LocationSettings properties so the app boots even before migrations run

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b42dd2be48321b64f0fa0f1f3facf