### PR TITLE
Fix tests setup and constant definitions

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -1,5 +1,5 @@
 <?php
-const CURRENCY_LOCALE = [
+defined('CURRENCY_LOCALE') || define('CURRENCY_LOCALE', [
     'af_NA' => "Afrikaans (Namibia)",
     'af_ZA' => "Afrikaans (South Africa)",
     'af' => "Afrikaans",
@@ -436,13 +436,13 @@ const CURRENCY_LOCALE = [
     'yo' => "Yoruba",
     'zu_ZA' => "Zulu (South Africa)",
     'zu' => "Zulu"
-];
+]);
 
 
-const CLASSIFIED_MARKETPLACE = 'classified';
-const ONLINE_SHOP_MARKETPLACE = 'online_shop';
-const VEHICLE_RENTAL_MARKETPLACE = 'vehicle_rental';
-const POINT_SYSTEM_MARKETPLACE = 'point_system';
+defined('CLASSIFIED_MARKETPLACE') || define('CLASSIFIED_MARKETPLACE', 'classified');
+defined('ONLINE_SHOP_MARKETPLACE') || define('ONLINE_SHOP_MARKETPLACE', 'online_shop');
+defined('VEHICLE_RENTAL_MARKETPLACE') || define('VEHICLE_RENTAL_MARKETPLACE', 'vehicle_rental');
+defined('POINT_SYSTEM_MARKETPLACE') || define('POINT_SYSTEM_MARKETPLACE', 'point_system');
 
-const RESERVATION_TYPE_RETAIL =  'retail';
-const RESERVATION_TYPE_POINT_VAULT =  'point_vault';
+defined('RESERVATION_TYPE_RETAIL') || define('RESERVATION_TYPE_RETAIL', 'retail');
+defined('RESERVATION_TYPE_POINT_VAULT') || define('RESERVATION_TYPE_POINT_VAULT', 'point_vault');

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -21,7 +21,7 @@ class UserFactory extends Factory
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'password' => bcrypt('password'), // password
             'remember_token' => Str::random(10),
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,14 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $installed = storage_path('installed');
+        if (! file_exists($installed)) {
+            file_put_contents($installed, 'installed');
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- prevent constant redefinition warnings
- hash passwords in the factory using current config
- ensure tests bypass installation check

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685653b0ac148321a54e19e01a324f25