### PR TITLE
Fix profile route tests

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/my-account', MyAccount::class)->name('my-account');
     Route::get('/my-messages', MyMessages::class)->name('my-messages');
     Route::get('/my-profile', MyProfile::class)->name('my-profile');
+    Route::get('/profile', [\App\Http\Controllers\ProfileController::class, 'edit'])->name('profile.edit');
+    Route::patch('/profile', [\App\Http\Controllers\ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile', [\App\Http\Controllers\ProfileController::class, 'destroy'])->name('profile.destroy');
     Route::get('/my-favorites', MyFavorites::class)->name('my-favorites');
     Route::get('/verification-required', VerificationRequired::class)->name('verification-required');
     Route::get('/ad-modifications/{id}', AdModifications::class)->name('ad-modifications');


### PR DESCRIPTION
## Summary
- add profile routes to `routes/web.php`

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685654f219c08321b796b232e7524a92