### PR TITLE
Fix currency format error when price is null

### DIFF
--- a/app/Helper/helper.php
+++ b/app/Helper/helper.php
@@ -760,10 +760,15 @@ if (!function_exists('getVerificationFields')) {
 if (!function_exists('formatPriceWithCurrency')) {
     function formatPriceWithCurrency($price)
     {
+        // If the price is null, return the localized "N/A" message
+        if ($price === null) {
+            return __('messages.t_N/A');
+        }
+
         $currencySymbol = config('app.currency_symbol'); // Fetch currency symbol from config
         $locale = getPaymentSystemSetting('currency_locale') ?? 'en_US'; // Default to 'en_US' if not set
 
-        $formattedPrice = Number::format($price, locale: $locale);
+        $formattedPrice = Number::format(floatval($price), locale: $locale);
 
         return isDisplayCurrencyAfterPrice()
             ? "{$formattedPrice} {$currencySymbol}"


### PR DESCRIPTION
## Summary
- handle null prices in `formatPriceWithCurrency`

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857707eed8c8321acdd9bc86fcf8b8f