### PR TITLE
Fix update file path

### DIFF
--- a/app/Filament/Pages/System/VersionUpdate.php
+++ b/app/Filament/Pages/System/VersionUpdate.php
@@ -516,7 +516,9 @@ class VersionUpdate extends Page
 
                 // Define storage parameters
                 $disk = 'local';
-                $destinationPath = ''; // Store directly in 'storage/app'
+                // Laravel's putFileAs throws a ValueError if the path is empty
+                // Pass a dot to indicate the root of the disk's storage path
+                $destinationPath = '.'; // Store directly in 'storage/app'
                 $newFileName = 'source-code.zip';
 
                 // Store the uploaded file


### PR DESCRIPTION
## Summary
- fix ValueError when storing update zip by using `.` as destination path

## Testing
- `npm test --silent`
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685784797c9883218f552f85e55ab94c