### PR TITLE
Fix media filesystem config

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,6 +56,7 @@ return [
             'driver' => 'local',
             'root'   => public_path('media'),
             'url'    => env('APP_URL').'/media',
+            'throw'  => false,
             'permissions' => [
                 'dir' => [
                     'public' => 0777,


### PR DESCRIPTION
## Summary
- add `'throw' => false` to the `media` filesystem disk

## Testing
- `php artisan config:clear` *(fails: `php: command not found`)*
- `php artisan config:cache` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68578a30f8a88321b9ac44c52e710b44