### PR TITLE
Add debug logs for upload paths

### DIFF
--- a/app/Filament/Pages/System/AddonManager.php
+++ b/app/Filament/Pages/System/AddonManager.php
@@ -187,6 +187,15 @@ class AddonManager extends Page implements HasTable
             $tempFile = $this->data['upload'][$fileIdentifier];
 
             $this->uploadProgress = 45;
+            // Debugging information to trace storage parameters
+            $debugInfo = sprintf(
+                'Storing addon on disk %s at %s/%s',
+                $disk,
+                $destinationPath,
+                $newFileName
+            );
+            $this->logMessage('Addon Upload', $debugInfo);
+
             // Store the uploaded file
             $zipPath = Storage::disk($disk)->putFileAs($destinationPath, $tempFile, $newFileName);
             $this->logMessage('Addon Upload', 'Addon ZIP file stored at ' . $zipPath);

--- a/app/Filament/Pages/System/VersionUpdate.php
+++ b/app/Filament/Pages/System/VersionUpdate.php
@@ -521,6 +521,15 @@ class VersionUpdate extends Page
                 $destinationPath = '.'; // Store directly in 'storage/app'
                 $newFileName = 'source-code.zip';
 
+                // Debugging information to trace storage parameters
+                $debugInfo = sprintf(
+                    'Storing file on disk %s at %s/%s',
+                    $disk,
+                    $destinationPath,
+                    $newFileName
+                );
+                $this->logMessage('Update Execution', $debugInfo);
+
                 // Store the uploaded file
                 Storage::disk($disk)->putFileAs($destinationPath, $tempFile, $newFileName);
                 $this->logMessage('Update Execution', 'New update file stored');


### PR DESCRIPTION
## Summary
- add log info in VersionUpdate to show disk & path used for file uploads
- add log info in AddonManager for debugging file uploads

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578d13cf6c8321bc50ae43c919c0e8