### PR TITLE
Handle missing temp file path before storing uploads

### DIFF
--- a/app/Filament/Pages/System/AddonManager.php
+++ b/app/Filament/Pages/System/AddonManager.php
@@ -197,7 +197,18 @@ class AddonManager extends Page implements HasTable
             $this->logMessage('Addon Upload', $debugInfo);
 
             // Store the uploaded file
-            $zipPath = Storage::disk($disk)->putFileAs($destinationPath, $tempFile, $newFileName);
+            // Ensure the temporary file has a valid path before storing
+            if (empty($tempFile->getRealPath())) {
+                $this->uploadProgress = 0;
+                $this->logMessage('Addon Upload', 'Temporary file path missing');
+                Notification::make()
+                    ->title('Failed to upload addon')
+                    ->danger()
+                    ->send();
+                return;
+            }
+
+            $zipPath = Storage::disk($disk)->putFileAs($destinationPath ?: '.', $tempFile, $newFileName);
             $this->logMessage('Addon Upload', 'Addon ZIP file stored at ' . $zipPath);
 
             $extractPath = storage_path('app/temp_addon');

--- a/app/Filament/Pages/System/VersionUpdate.php
+++ b/app/Filament/Pages/System/VersionUpdate.php
@@ -530,8 +530,18 @@ class VersionUpdate extends Page
                 );
                 $this->logMessage('Update Execution', $debugInfo);
 
-                // Store the uploaded file
-                Storage::disk($disk)->putFileAs($destinationPath, $tempFile, $newFileName);
+                // Store the uploaded file if the path is available
+                if (empty($tempFile->getRealPath())) {
+                    $this->uploadProgress = 0;
+                    $this->logMessage('Update Execution', 'Temporary file path missing');
+                    Notification::make()
+                        ->title('Failed to upload update file')
+                        ->danger()
+                        ->send();
+                    return;
+                }
+
+                Storage::disk($disk)->putFileAs($destinationPath ?: '.', $tempFile, $newFileName);
                 $this->logMessage('Update Execution', 'New update file stored');
                 $this->uploadProgress = 20;
                 // Execute the update process


### PR DESCRIPTION
## Summary
- validate temporary uploaded file paths before storing

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857929fe7c88321b417d95f26d67969