### PR TITLE
Add debugging tools and storage improvements

### DIFF
--- a/app/Console/Commands/CheckUploads.php
+++ b/app/Console/Commands/CheckUploads.php
@@ -1,0 +1,52 @@
+<?php
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class CheckUploads extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'debug:uploads';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Verifica configuraci\xC3\xB3n y permisos del sistema de archivos';
+
+    public function handle()
+    {
+        $disk = config('filesystems.default');
+        $path = config('filesystems.disks.' . $disk . '.root');
+
+        $this->info("Disk: {$disk}");
+        $this->info("Root path: {$path}");
+
+        if (!is_dir($path)) {
+            $this->error('Directorio no existe');
+            return Command::FAILURE;
+        }
+
+        if (!is_writable($path)) {
+            $this->error('Directorio sin permisos de escritura');
+            return Command::FAILURE;
+        }
+
+        $this->info('Directorio v\xC3\xA1lido y escribible');
+        $test = Storage::disk($disk)->put('test.txt', 'OK');
+        if ($test) {
+            $this->info('Escritura correcta');
+            Storage::disk($disk)->delete('test.txt');
+            return Command::SUCCESS;
+        }
+
+        $this->error('Fallo al escribir');
+        return Command::FAILURE;
+    }
+}

--- a/app/Filament/Pages/System/VersionUpdate.php
+++ b/app/Filament/Pages/System/VersionUpdate.php
@@ -473,6 +473,14 @@ class VersionUpdate extends Page
         $this->validate();
         // Check if an update file has been uploaded
         if (isset($this->data['upload']) && !empty($this->data['upload'])) {
+            $fileIdentifier = array_key_first($this->data['upload']);
+            $tempFile = $this->data['upload'][$fileIdentifier];
+            Log::debug('Livewire upload start', [
+                'originalName' => $tempFile->getClientOriginalName(),
+                'size' => $tempFile->getSize(),
+                'disk' => config('livewire.temporary_file_upload.disk'),
+                'directory' => config('livewire.temporary_file_upload.directory'),
+            ]);
 
             $this->uploadProgress = 0;
             // Notify the user that the process has started
@@ -510,9 +518,7 @@ class VersionUpdate extends Page
                     $this->logMessage('Update Execution', 'Existing update file deleted');
                 }
 
-                // Retrieve the uploaded file
-                $fileIdentifier = array_key_first($this->data['upload']);
-                $tempFile = $this->data['upload'][$fileIdentifier];
+                // Uploaded file was captured earlier
 
                 // Define storage parameters
                 $disk = 'local';

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -72,5 +72,6 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => EnsureEmailIsVerified::class,
         'common' => CommonMiddleware::class,
+        'debug.upload' => \App\Http\Middleware\DebugFileUpload::class,
     ];
 }

--- a/app/Http/Middleware/DebugFileUpload.php
+++ b/app/Http/Middleware/DebugFileUpload.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class DebugFileUpload
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->hasFile('file')) {
+            $file = $request->file('file');
+            Log::debug('Upload intercepted', [
+                'name' => $file->getClientOriginalName(),
+                'tempPath' => $file->getPathname(),
+                'targetDisk' => config('filesystems.default'),
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -54,15 +54,10 @@ return [
 
         'media' => [
             'driver' => 'local',
-            'root'   => public_path('media'),
-            'url'    => env('APP_URL').'/media',
+            'root'   => storage_path('app/media'),
+            'url'    => env('APP_URL').'/storage/media',
+            'visibility' => 'public',
             'throw'  => false,
-            'permissions' => [
-                'dir' => [
-                    'public' => 0777,
-                    'private' => 0755,
-                ],
-            ],
         ],
 
         's3' => [
@@ -94,6 +89,7 @@ return [
 
     'links' => [
         public_path('storage') => storage_path('app/public'),
+        public_path('media') => storage_path('app/media'),
     ],
 
 ];


### PR DESCRIPTION
## Summary
- switch `media` disk to use storage path and add symlink
- add `CheckUploads` console command to verify disk permissions
- log upload details in `VersionUpdate` Livewire page
- add `DebugFileUpload` middleware with kernel alias

## Testing
- `composer --version` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685796d4a36083218328bdda599dab3d