### PR TITLE
Fix media tmp directory creation

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -47,6 +47,7 @@ use App\Settings\UiCustomizationSettings;
 use App\Settings\VehicleRentalSettings;
 use App\Settings\WhatsappSettings;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -66,6 +67,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(MailManager $mailManager): void
     {
+        if (!Storage::disk('media')->exists('livewire-tmp')) {
+            Storage::disk('media')->makeDirectory('livewire-tmp');
+        }
         // Fetching active languages and mapping them to an array of language codes
         $activeLanguages = [];
         try {


### PR DESCRIPTION
## Summary
- ensure the `livewire-tmp` directory is created on the `media` disk at boot

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68579f92865c8321aba637190db649ba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the required temporary directory for media storage is automatically created if missing, improving reliability for file uploads and related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->