### PR TITLE
Update README with file upload instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ In order to ensure that the Laravel community is welcoming to all, please review
 
 If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
 
+## File Uploads
+
+Laravel uses the `public/media` disk for uploaded files. After cloning the project you should run:
+
+```bash
+php artisan storage:link
+```
+
+This command creates the necessary symbolic link so that files stored in `storage` are publicly accessible. Ensure the directories `public/media` and `public/media/livewire-tmp` are writable by the web server. The `AppServiceProvider` boot method will automatically create the `livewire-tmp` directory if it does not already exist.
+
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary
- document how to set up uploaded files via `php artisan storage:link`
- mention writable media folders and AppServiceProvider's role

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857a918235c83219913c2687b1d9c38