### PR TITLE
Check upload error before storing file

### DIFF
--- a/app/Livewire/UploadImage.php
+++ b/app/Livewire/UploadImage.php
@@ -35,6 +35,14 @@ class UploadImage extends Component
 
         Log::info('UploadImage: validation passed');
 
+        // Check for upload errors before proceeding
+        if (!isset($_FILES['photo']) || ($_FILES['photo']['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+            $errorCode = $_FILES['photo']['error'] ?? 'unknown';
+            Log::error('UploadImage: upload error', ['error' => $errorCode]);
+            $this->addError('photo', 'File upload failed. Please try again.');
+            return;
+        }
+
         $path = 'uploads';
         if (empty($path)) {
             Log::error('UploadImage: storage path is empty');


### PR DESCRIPTION
## Summary
- ensure `photo` upload was successful before storing

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a931ee008321a1ee0c0fc8d77f06