### PR TITLE
Fix Livewire image upload error

### DIFF
--- a/app/Exceptions/InvalidUploadException.php
+++ b/app/Exceptions/InvalidUploadException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class InvalidUploadException extends Exception
+{
+    // Custom exception for invalid uploads
+}


### PR DESCRIPTION
## Summary
- add `InvalidUploadException` for clearer upload errors
- validate file path and use `storePublicly` in `UploadImage`
- log upload steps and surface friendly error messages

## Testing
- `composer test` *(fails: composer not installed)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685861948a5483219c523af5d4da5f2f