### PR TITLE
Fix file upload path errors

### DIFF
--- a/app/Http/Controllers/FileUploadController.php
+++ b/app/Http/Controllers/FileUploadController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 
 class FileUploadController extends Controller
 {
@@ -23,18 +22,16 @@ class FileUploadController extends Controller
             'valid' => $file->isValid(),
         ]);
 
-        if (! $file->isValid()) {
-            throw new \RuntimeException('Uploaded file is not valid');
+        if (! $file->isValid() || ! $file->getClientOriginalName()) {
+            Log::error('Upload fallido: archivo inválido o vacío');
+            abort(422, 'Archivo inválido o vacío');
         }
 
-        $filename = $file->getClientOriginalName() ?: Str::random(10) . '.jpg';
-
-        if ($filename === '') {
-            throw new \RuntimeException('Filename for upload is empty');
-        }
+        $path = $file->storePublicly('livewire-tmp', 'media');
+        Log::info('Upload exitoso', ['path' => $path]);
 
         return [
-            'path' => $file->storeAs('uploads', $filename, 'media'),
+            'path' => $path,
         ];
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Livewire\Ad\VerificationRequired;
 use App\Livewire\AdType\AdOverview;
 use App\Livewire\AdType\AdTypeCollection;
 use App\Livewire\Notification\Registration;
+use App\Http\Controllers\FileUploadController;
 use App\Livewire\Reservation\CartSummary;
 use App\Livewire\Reservation\CheckoutSummary;
 use App\Livewire\Reservation\Purchases\MyPurchases;
@@ -57,6 +58,9 @@ Route::group([], function () {
     // Route::get('/location/{location}/{category}/{subcategory?}', AdList::class)->name('location-category');
     Route::get('/notification/register', Registration::class);
     Route::get('/upload-image', \App\Livewire\UploadImage::class)->name('upload-image');
+    Route::post('/livewire/upload-file', [FileUploadController::class, 'store'])
+        ->middleware(config('livewire.temporary_file_upload.middleware'))
+        ->name('livewire.upload-file');
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {


### PR DESCRIPTION
## Summary
- patch file upload logic to validate and use storePublicly
- expose custom Livewire upload-file route using new controller

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685865dacfb88321a0d2df07fe3e3109